### PR TITLE
Add EBU spinlocking to allow EBU usage being shared with other drivers

### DIFF
--- a/kernel/fbtft/src/fb_ili9341_eb904.c
+++ b/kernel/fbtft/src/fb_ili9341_eb904.c
@@ -267,6 +267,14 @@ static int init_display_smp(struct fbtft_par *par)
 {
 	unsigned long lockflags;
 
+// As a reminder, the EBU setup in original eb904 U-Boot for the lcd. From lcd_Init() in file
+// package/infineon-utilities/feeds/ifx_feeds_uboot/open_uboot/src.904dsl/common/main.c:
+//
+//	*(unsigned long*)0xbe105328 = 0x160000f1;	// BSP_EBU_ADDSEL2 register
+//	*(unsigned long*)0xbe105368 = 0x1d3dd;		// BSP_EBU_BUSCON2 register
+//
+// Currently this is configured by U-Boot. Maybe the driver should do that too?
+
 	par->fbtftops.reset(par);
 
 	SPIN_LOCK_IRQSAVE(&ebu_lock, lockflags);


### PR DESCRIPTION
Without correct EBU locking on the eb904, NAND writes will flash corrupt data if SMP is turned on and this LCD driver is active. These changes add spinlocking using the global 'ebu_lock' which is already present in the lantiq part of the kernel.

Tested together with these [eb904 changes](https://github.com/Quallenauge/Easybox-904-XDSL/pull/12).
Sysupgrading a new system (kernel in mtd2 and rootfs in mtd12/ubi with 512B sub-pages) works flawless now with SMP when the LCD is active.

Used as running system when flashing: An initramfs containing the new stuff.
Flashed system: the sysupgrade.bin file built together with the initramfs.

Signed-off-by: arny <arnysch@gmx.net>