### PR TITLE
Setup ebu registers which are relevant for eb904 display, and some driver cleanup

### DIFF
--- a/kernel/fbtft/Makefile
+++ b/kernel/fbtft/Makefile
@@ -23,7 +23,8 @@ define KernelPackage/fbtft-eb904
   SUBMENU:=$(VIDEO_MENU)
   TITLE:=EasyBox 904 display support
 # Include kmod-fbcon in case the display should be used for console output
-  DEPENDS:=@(TARGET_lantiq_xrx200_DEVICE_lantiq_vgv952cjw33-e-ir) kmod-fb kmod-fb-cfb-copyarea kmod-fb-cfb-fillrect kmod-fb-cfb-imgblt kmod-fb-sys-fops
+  DEPENDS:=@(TARGET_lantiq_xrx200_DEVICE_lantiq_vgv952cjw33-e-ir) +kmod-fb +kmod-fb-sys-fops
+  
   KCONFIG:= \
   	CONFIG_STAGING=y \
 	CONFIG_FB_TFT=y \


### PR DESCRIPTION
Previously the ebu registers relevant for the eb904 display were (incompletely) setup in file arch/mips/lantiq/xway/sysctrl.c. This means that device specific code was in a common file used by all lantiq xway devices.

This change implements this the same way as the nand driver in xway_nand.c,
i.e. the device driver specific ebu setup is done by the device driver.

Signed-off-by: arny <arnysch@gmx.net>